### PR TITLE
Course Data Error Fix For The Curriculum Page

### DIFF
--- a/data/courses/generic-cc.json
+++ b/data/courses/generic-cc.json
@@ -1,7 +1,7 @@
 {
   "id": "",
   "type": "course",
-  "credits": "3",
+  "credits": "3-4",
   "ects": "5",
   "hours": "",
   "categories": ["general"],

--- a/data/courses/generic-hss.json
+++ b/data/courses/generic-hss.json
@@ -1,7 +1,7 @@
 {
   "id": "",
   "type": "course",
-  "credits": "3",
+  "credits": "3-4",
   "ects": "5",
   "hours": "",
   "categories": ["general"],

--- a/data/courses/htr311.json
+++ b/data/courses/htr311.json
@@ -1,8 +1,8 @@
 {
   "id": "",
   "type": "course",
-  "credits": "3",
-  "ects": "5",
+  "credits": "2",
+  "ects": "3",
   "hours": "",
   "categories": ["general"],
   "languages": {

--- a/data/courses/htr312.json
+++ b/data/courses/htr312.json
@@ -1,8 +1,8 @@
 {
   "id": "",
   "type": "course",
-  "credits": "3",
-  "ects": "5",
+  "credits": "2",
+  "ects": "3",
   "hours": "",
   "categories": ["general"],
   "languages": {

--- a/data/courses/ie306.json
+++ b/data/courses/ie306.json
@@ -1,7 +1,7 @@
 {
   "id": "ie306",
   "type": "course",
-  "credits": "3",
+  "credits": "4",
   "ects": "7",
   "hours": "3+0+2",
   "categories": ["engineering"],

--- a/data/courses/ie310.json
+++ b/data/courses/ie310.json
@@ -1,7 +1,7 @@
 {
   "id": "ie310",
   "type": "course",
-  "credits": "3",
+  "credits": "4",
   "ects": "5",
   "hours": "3+0+2",
   "categories": ["engineering"],
@@ -15,5 +15,5 @@
       "description": ""
     }
   },
-  "prerequisites": ["cmpe201"]
+  "prerequisites": ["math201"]
 }


### PR DESCRIPTION
Did some bug fixes for the curriculum page. 

The following courses had wrong course credit data: 
- IE306
- IE310
- HTR311
- HTR312
- Generic HSS
- Generic CC

IE310 had wrong prerequisite course data.

